### PR TITLE
Add revoke-all to account actions

### DIFF
--- a/lib/account.rb
+++ b/lib/account.rb
@@ -9,7 +9,7 @@ module Nylas
     parameter :billing_state
 
     def _perform_account_action!(action)
-      raise UnexpectedAccountAction.new unless action == "upgrade" || action == "downgrade"
+      raise UnexpectedAccountAction.new unless action == "upgrade" || action == "downgrade" || action == "revoke-all"
 
       collection = ManagementModelCollection.new(Account, @_api, {:account_id=>@account_id})
 


### PR DESCRIPTION
The `revoke_all!` method was added to accounts in #4, but we also need to add it as an expected account action.